### PR TITLE
Fix width for .works-modal-content on Responsive

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -18,7 +18,7 @@ Vue.component('OpenModal', {
     <div class="work-modal-overlay" @click="exitModal">
       <div class="works-modal-content" @click="stopModal">
         <slot name="img" :img-info="imgInfo"></slot>
-        <button type="button" class="work-modal-close" @click="exitModal">close</button>
+        <button type="button" class="work-modal-close" @click="exitModal">CLOSE</button>
       </div>
     </div>
   </transition>

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -333,7 +333,7 @@ h1 a {
       width: 30%;
     }
     &-modal-close {
-      margin: 10% 0;
+      margin: 10% auto;
     }
   }
   // Modal Fade
@@ -536,6 +536,10 @@ h1 a {
   }
   // Works
   #works {
+    .works-modal-content {
+      width: 90%;
+      height: 90%;
+    }
     .modal-overlay {
       padding: 10% 0;
     }
@@ -568,6 +572,10 @@ h1 a {
   body, p, button {
     font-size: 14px;
     letter-spacing: normal;
+  }
+  button {
+    padding: 20px 90px;
+    width: 100%;
   }
   h2 {
     font-size: 60px;
@@ -604,6 +612,9 @@ h1 a {
       }
       &-more {
         width: 100%;
+      }
+      &-scope {
+        text-align: center;
       }
     }
   }


### PR DESCRIPTION
## 概要

#51 

## 変更内容

- レスポンシブ時のwidthを変更
- モーダル内のCLOSEボタンのサイズをレスポンシブ時のみ変更

<img width="336" alt="スクリーンショット 2021-02-04 22 10 50" src="https://user-images.githubusercontent.com/58844223/106897204-f669f980-6735-11eb-80eb-fd3c3e292815.png">

## 影響範囲

特になし。

## 動作要件

特になし。

## 備考

特になし。